### PR TITLE
회원가입시 얼굴 사진을 등록하는 기능 구현

### DIFF
--- a/src/main/java/com/mango/amango/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/mango/amango/domain/auth/presentation/AuthController.java
@@ -13,6 +13,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import static org.springframework.http.HttpStatus.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,9 +28,12 @@ public class AuthController {
     private final ReissueTokenService reissueTokenService;
 
     @PostMapping
-    public ResponseEntity<Void> signUp(@Valid @RequestBody SignUpReq request) {
-        signUpService.signUp(request);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<Void> signUp(
+            @Valid @RequestPart("request") SignUpReq request,
+            @RequestPart("image") MultipartFile image
+    ) {
+        signUpService.signUp(request, image);
+        return ResponseEntity.status(CREATED).build();
     }
 
     @PostMapping("/login")

--- a/src/main/java/com/mango/amango/domain/auth/service/SignUpService.java
+++ b/src/main/java/com/mango/amango/domain/auth/service/SignUpService.java
@@ -1,8 +1,9 @@
 package com.mango.amango.domain.auth.service;
 
 import com.mango.amango.domain.auth.presentation.dto.request.SignUpReq;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface SignUpService {
 
-    void signUp(SignUpReq request);
+    void signUp(SignUpReq request, MultipartFile image);
 }

--- a/src/main/java/com/mango/amango/domain/auth/service/impl/SignUpServiceImpl.java
+++ b/src/main/java/com/mango/amango/domain/auth/service/impl/SignUpServiceImpl.java
@@ -4,10 +4,15 @@ import com.mango.amango.domain.auth.presentation.dto.request.SignUpReq;
 import com.mango.amango.domain.auth.service.SignUpService;
 import com.mango.amango.domain.user.entity.User;
 import com.mango.amango.domain.user.service.UserService;
+import com.mango.amango.global.exception.CustomErrorCode;
+import com.mango.amango.global.exception.CustomException;
+import com.mango.amango.global.file.s3.S3ClientService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 
 @Service
 @Transactional
@@ -16,16 +21,16 @@ public class SignUpServiceImpl implements SignUpService {
 
     private final UserService userService;
     private final PasswordEncoder passwordEncoder;
+    private final S3ClientService s3ClientService;
 
     @Override
-    public void signUp(SignUpReq request) {
-
-        //TODO 이메일 인증
-
+    public void signUp(SignUpReq request, MultipartFile image) {
         userService.saveUser(User.builder()
                 .email(request.email())
                 .nickname(request.nickName())
                 .password(passwordEncoder.encode(request.password()))
+                .faceImageUrl(s3ClientService.upload(image, ObjectCannedACL.BUCKET_OWNER_READ)
+                        .orElseThrow(() -> new CustomException(CustomErrorCode.FILE_PROCESSING_ERROR)))
                 .build()
         );
     }

--- a/src/main/java/com/mango/amango/domain/product/service/impl/CreateProductServiceImpl.java
+++ b/src/main/java/com/mango/amango/domain/product/service/impl/CreateProductServiceImpl.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import static software.amazon.awssdk.services.s3.model.ObjectCannedACL.*;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -26,7 +28,7 @@ public class CreateProductServiceImpl implements CreateProductService {
                 .title(request.title())
                 .description(request.description())
                 .price(request.price())
-                .imageUrl(s3ClientService.upload(image))
+                .imageUrl(s3ClientService.upload(image, PUBLIC_READ).orElse(null))
                 .user(userService.getCurrentUser())
                 .build());
     }

--- a/src/main/java/com/mango/amango/domain/user/entity/User.java
+++ b/src/main/java/com/mango/amango/domain/user/entity/User.java
@@ -28,6 +28,8 @@ public class User {
     @Column(nullable = false)
     private String password;
 
+    private String faceImageUrl;
+
     private String profile;
 
     @Builder.Default

--- a/src/main/java/com/mango/amango/global/file/s3/S3ClientService.java
+++ b/src/main/java/com/mango/amango/global/file/s3/S3ClientService.java
@@ -13,6 +13,7 @@ import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.UUID;
 
 import static com.mango.amango.global.file.ImageUtil.*;
@@ -27,10 +28,10 @@ public class S3ClientService {
     private String bucket;
     private final S3Client s3Client;
 
-    public String upload(MultipartFile multipartFile) {
+    public Optional<String> upload(MultipartFile multipartFile, ObjectCannedACL acl) {
         try {
             if (multipartFile.isEmpty()) {
-                return null;
+                return Optional.empty();
             }
 
             String randomName = UUID.randomUUID().toString();
@@ -40,14 +41,14 @@ public class S3ClientService {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                     .bucket(bucket)
                     .key(fileName)
-                    .acl(ObjectCannedACL.PUBLIC_READ)
+                    .acl(acl)
                     .contentType(contentType)
                     .contentLength(multipartFile.getSize())
                     .build();
             s3Client.putObject(putObjectRequest, RequestBody.fromBytes(multipartFile.getBytes()));
 
             GetUrlRequest request = GetUrlRequest.builder().bucket(bucket).key(fileName).build();
-            return s3Client.utilities().getUrl(request).toString();
+            return Optional.of(s3Client.utilities().getUrl(request).toString());
 
         } catch (IOException e) {
             throw new CustomException(CustomErrorCode.FILE_PROCESSING_ERROR);


### PR DESCRIPTION
💡 개요
회원가입시 얼굴 사진을 등록하는 기능을 구현했습니다.

📃 작업내용
- 회원가입시 얼굴 사진을 받고 S3에 관리자만 볼 수 있도록 저장

🔀 변경사항
- User Entity에 얼굴 사진 경로를 저장하는 컬럼 추가
- 이미지 업로드시 ACL 정책 선택하도록 변경
- 이미지 업로드 기능의 예외처리를 위한 Optional 반환하도록 변경