### PR TITLE
403으로 반환되던 처리되지 않은 일반 예외를 커스텀 인증 예외 처리로 수정

### DIFF
--- a/src/main/java/com/mango/amango/global/exception/CustomErrorCode.java
+++ b/src/main/java/com/mango/amango/global/exception/CustomErrorCode.java
@@ -7,10 +7,16 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum CustomErrorCode {
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "권한 증명에 실패했습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 페이지 입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 발생했습니다."),
+
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "유효하지 않은 비밀번호 입니다."),
     INVALID_EMAIL(HttpStatus.UNAUTHORIZED, "유효하지 않은 이메일 입니다."),
     MALFORMED_TOKEN(HttpStatus.BAD_REQUEST, "잘못된 토큰 형식 입니다."),
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 유저 입니다."),
+    EXIST_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일 입니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "Refresh 토큰을 찾을 수 없습니다."),
     VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "유효하지 않는 요청 형식입니다."),
 

--- a/src/main/java/com/mango/amango/global/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/mango/amango/global/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,56 @@
+package com.mango.amango.global.security;
+
+import com.mango.amango.global.exception.CustomErrorCode;
+import com.mango.amango.global.exception.CustomException;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import java.io.IOException;
+
+@Primary
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final HandlerExceptionResolver resolver;
+
+    public CustomAuthenticationEntryPoint(@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        resolver.resolveException(request, response, null, getCustomException(response, authException));
+    }
+
+    private CustomException getCustomException(HttpServletResponse response, AuthenticationException authException) {
+        if (isSuccessResponse(response) && isAuthError(authException)) {
+            return new CustomException(CustomErrorCode.UNAUTHORIZED);
+
+        } else {
+            return switch (response.getStatus()) {
+                case 401 -> new CustomException(CustomErrorCode.UNAUTHORIZED);
+                case 403 -> new CustomException(CustomErrorCode.FORBIDDEN);
+                case 404 -> new CustomException(CustomErrorCode.NOT_FOUND);
+                case 500 -> new CustomException(CustomErrorCode.INTERNAL_SERVER_ERROR);
+                default -> throw authException;
+
+            };
+        }
+    }
+
+    private boolean isSuccessResponse(HttpServletResponse response) {
+        return response.getStatus() == 200 || response.getStatus() == 201;
+    }
+
+    private boolean isAuthError(AuthenticationException authException) {
+        return authException instanceof InsufficientAuthenticationException;
+    }
+}

--- a/src/main/java/com/mango/amango/global/security/configs/SecurityConfig.java
+++ b/src/main/java/com/mango/amango/global/security/configs/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -25,6 +26,7 @@ public class SecurityConfig {
     public static final String[] PERMITTED_URI = {"/auth", "/auth/login"};
     private final JwtService jwtService;
     private final UserService userService;
+    private final AuthenticationEntryPoint authenticationEntryPoint;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -53,7 +55,8 @@ public class SecurityConfig {
                 .addFilterBefore(new JwtAuthenticationFilter(jwtService, userService),
                         UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new CustomExceptionFilter(),
-                        JwtAuthenticationFilter.class);
+                        JwtAuthenticationFilter.class)
+                .exceptionHandling((exception) -> exception.authenticationEntryPoint(authenticationEntryPoint))
         ;
 
         return http.build();


### PR DESCRIPTION
💡 개요
403으로 반환되던 처리되지 않은 일반 예외를 커스텀 인증 예외처리 기능을 구현하여 해결했습니다.

📃 작업내용
- CustomAuthenticationEntryPoint 클래스를 추가하여 등록했습니다.
- CustomErrorCode에 일반 예외를 추가했습니다.
