### PR TITLE
1MB 이상의 요청에 413에러코드를 반환하는 문제 해결

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,11 @@ spring:
           auto: update
     show-sql: true
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
 jwt:
   access-secret: ${ACCESS_SECRET}
   refresh-secret: ${REFRESH_SECRET}


### PR DESCRIPTION
💡 개요
1MB 이상의 요청에 413에러코드를 반환하는 문제를 해결했습니다.

📃 작업내용
- 1MB 이상의 요청에 413에러코드를 반환하는 문제 해결

🔀 변경사항
- 10MB의 요청까지 받을 수 있도록 변경